### PR TITLE
Put some exception

### DIFF
--- a/src/FB2Library/FB2Reader.cs
+++ b/src/FB2Library/FB2Reader.cs
@@ -22,7 +22,7 @@ namespace FB2Library
 			if (settings == null)
 				throw new ArgumentNullException(nameof(settings));
 
-            return Task.Factory.StartNew(() =>
+			return Task.Factory.StartNew(() =>
 			{
 				var file = new FB2File();
 				using (var reader = XmlReader.Create(stream, settings.ReaderSettings))

--- a/src/FB2Library/FB2Reader.cs
+++ b/src/FB2Library/FB2Reader.cs
@@ -19,8 +19,8 @@ namespace FB2Library
 		/// <returns></returns>
 		public Task<FB2File> ReadAsync(Stream stream, XmlLoadSettings settings)
 		{
-            if (settings == null)
-                throw new ArgumentNullException(nameof(settings));
+			if (settings == null)
+				throw new ArgumentNullException(nameof(settings));
 
             return Task.Factory.StartNew(() =>
 			{

--- a/src/FB2Library/FB2Reader.cs
+++ b/src/FB2Library/FB2Reader.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
@@ -18,7 +19,10 @@ namespace FB2Library
 		/// <returns></returns>
 		public Task<FB2File> ReadAsync(Stream stream, XmlLoadSettings settings)
 		{
-			return Task.Factory.StartNew(() =>
+            if (settings == null)
+                throw new ArgumentNullException(nameof(settings));
+
+            return Task.Factory.StartNew(() =>
 			{
 				var file = new FB2File();
 				using (var reader = XmlReader.Create(stream, settings.ReaderSettings))


### PR DESCRIPTION
I tried to use the library and I called ReadAsync() without settings parameter.
As result the library got Null Reference exception inside.
I think would be better if user could see exception explicitly.