### PR TITLE
title-info: add possibility to update authors, genres and translators

### DIFF
--- a/FB2Library/HeaderItems/ItemTitleInfo.cs
+++ b/FB2Library/HeaderItems/ItemTitleInfo.cs
@@ -37,7 +37,7 @@ namespace FB2Library.HeaderItems
         /// <summary>
         /// Translators if this is a translation
         /// </summary>
-        public IEnumerable<AuthorType> Translators
+        public List<AuthorType> Translators
         {
             get { return _translators; }
         }
@@ -55,7 +55,7 @@ namespace FB2Library.HeaderItems
         /// <summary>
         /// Genres of the item
         /// </summary>
-        public IEnumerable<TitleGenreType> Genres
+        public List<TitleGenreType> Genres
         {
             get { return _genres; }
         }
@@ -64,7 +64,7 @@ namespace FB2Library.HeaderItems
         /// <summary>
         /// Authors of this book
         /// </summary>
-        public IEnumerable<AuthorType> BookAuthors
+        public List<AuthorType> BookAuthors
         {
             get { return _bookAuthors; }
         }


### PR DESCRIPTION
It's not possible to update the book author, genre, or translator in the title-info tag after book parsing. Fixing this