### PR TITLE
Fix: 'a' tag doesn't support sub-tags

### DIFF
--- a/FB2Library/Elements/InternalLinkItem.cs
+++ b/FB2Library/Elements/InternalLinkItem.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 
 namespace FB2Library.Elements
@@ -9,19 +9,37 @@ namespace FB2Library.Elements
     public class InternalLinkItem : StyleType
     {
         private readonly XNamespace lNamespace = @"http://www.w3.org/1999/xlink";
-        
+
         public string Type { get; set; }
 
         public string HRef { get; set; }
 
-        public SimpleText LinkText { get; set; }
+        private readonly List<StyleType> _linkData = new List<StyleType>();
+        public List<StyleType> LinkData { get { return _linkData; } }
 
         internal const string Fb2InternalLinkElementName = "a";
 
 
         public override string ToString()
         {
-            return LinkText.ToString();
+            StringBuilder builder = new StringBuilder();
+            builder.Append("<a");
+            if (string.IsNullOrEmpty(Type))
+            {
+                builder.Append($" type='{Type}'");
+            }
+            if (string.IsNullOrEmpty(HRef))
+            {
+                builder.Append($" href='{HRef}'");
+            }
+            builder.Append(">");
+            foreach (var item in _linkData)
+            {
+                builder.Append(item.ToString());
+                builder.Append(" ");
+            }
+            builder.Append("</a>");
+            return builder.ToString();
         }
 
         internal void Load(XElement xLink)
@@ -36,22 +54,51 @@ namespace FB2Library.Elements
                 throw new ArgumentException("Element of wrong type passed", "xLink");
             }
 
-            LinkText = null;
-            //if (xLink.Value != null)
+            if (xLink.HasElements)
             {
-                LinkText = new SimpleText();
-                try
+                IEnumerable<XNode> childElements = xLink.Nodes();
+                foreach (var element in childElements)
                 {
-                    LinkText.Load(xLink);
+                    if ((element.NodeType == XmlNodeType.Element) && !IsSimpleText(element))
+                    {
+                        XElement xElement = (XElement)element;
+                        if (xElement.Name.LocalName == InlineImageItem.Fb2InlineImageElementName)
+                        {
+                            InlineImageItem image = new InlineImageItem();
+                            try
+                            {
+                                image.Load(xElement);
+                                _linkData.Add(image);
+                            }
+                            catch (Exception)
+                            {
+                            }
+                        }
+                    }
+                    else
+                    {
+                        SimpleText text = new SimpleText();
+                        try
+                        {
+                            text.Load(element);
+                            _linkData.Add(text);
+                        }
+                        catch (Exception)
+                        {
+                            continue;
+                        }
+                    }
                 }
-                catch (Exception)
-                {
-                    LinkText = null;
-                }
+            }
+            else if (!string.IsNullOrEmpty(xLink.Value))
+            {
+                SimpleText text = new SimpleText();
+                text.Load(xLink);
+                _linkData.Add(text);
             }
 
             XAttribute xTypeAttr = xLink.Attribute("type");
-            if ((xTypeAttr != null)&& (xTypeAttr.Value != null))
+            if ((xTypeAttr != null) && (xTypeAttr.Value != null))
             {
                 Type = xTypeAttr.Value;
             }
@@ -64,20 +111,35 @@ namespace FB2Library.Elements
 
         }
 
+        private bool IsSimpleText(XNode element)
+        {
+            // if not element than we assume simple text
+            if (element.NodeType != XmlNodeType.Element)
+            {
+                return true;
+            }
+            XElement xElement = (XElement)element;
+            if (xElement.Name.LocalName == InternalLinkItem.Fb2InternalLinkElementName)
+            {
+                throw new ArgumentException("Schema doesn't support nested links");
+            }
+            return xElement.Name.LocalName != InlineImageItem.Fb2InlineImageElementName;
+        }
+
         public XNode ToXML()
         {
             XElement xLink = new XElement(Fb2Const.fb2DefaultNamespace + Fb2InternalLinkElementName);
             if (!string.IsNullOrEmpty(Type))
-            { 
-                xLink.Add(new XAttribute("type",Type));
-            }
-            if(!string.IsNullOrEmpty(HRef))
             {
-                xLink.Add(new XAttribute(lNamespace + "href",HRef));
+                xLink.Add(new XAttribute("type", Type));
             }
-            if (LinkText != null)
+            if (!string.IsNullOrEmpty(HRef))
             {
-                xLink.Add(LinkText.ToXML());
+                xLink.Add(new XAttribute(lNamespace + "href", HRef));
+            }
+            foreach (StyleType childElements in _linkData)
+            {
+                xLink.Add(childElements.ToXML());
             }
             return xLink;
         }


### PR DESCRIPTION
For tag `<a type="note" l:href="#n1"><sup>1</sup></a>` following exception will be thrown:
```
System.ArgumentNullException: The empty string '' is not a valid local name. (Parameter 'name')
   at System.Xml.XmlConvert.VerifyNCName(String name, ExceptionType exceptionType)
   at System.Xml.XmlConvert.VerifyNCName(String name)
   at System.Xml.Linq.XName..ctor(XNamespace ns, String localName)
   at System.Xml.Linq.XNamespace.GetName(String localName, Int32 index, Int32 count)
   at System.Xml.Linq.XNamespace.GetName(String localName)
   at System.Xml.Linq.XNamespace.op_Addition(XNamespace ns, String localName)
   at FB2Library.Elements.SimpleText.ToXML() in FB2Library\Elements\SimpleText.cs:line 218
   at FB2Library.Elements.InternalLinkItem.ToXML() in FB2Library\Elements\InternalLinkItem.cs:line 80
   at FB2Library.Elements.ParagraphItem.ToXML() in FB2Library\Elements\ParagraphItem.cs:line 180
   at FB2Library.Elements.SectionItem.ToXML() in FB2Library\Elements\SectionItem.cs:line 328
   at FB2Library.Elements.BodyItem.ToXML() in FB2Library\Elements\BodyItem.cs:line 164
   at FB2Library.FB2File.ToXML(Boolean bExportHeaderOnly) in FB2Library\FB2File.cs:line 420```