### PR TITLE
Add 'style' tag processing

### DIFF
--- a/FB2Library/Elements/InternalLinkItem.cs
+++ b/FB2Library/Elements/InternalLinkItem.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 
 namespace FB2Library.Elements
@@ -9,19 +9,37 @@ namespace FB2Library.Elements
     public class InternalLinkItem : StyleType
     {
         private readonly XNamespace lNamespace = @"http://www.w3.org/1999/xlink";
-        
+
         public string Type { get; set; }
 
         public string HRef { get; set; }
 
-        public SimpleText LinkText { get; set; }
+        private readonly List<StyleType> _linkData = new List<StyleType>();
+        public List<StyleType> LinkData { get { return _linkData; } }
 
         internal const string Fb2InternalLinkElementName = "a";
 
 
         public override string ToString()
         {
-            return LinkText.ToString();
+            StringBuilder builder = new StringBuilder();
+            builder.Append("<a");
+            if (string.IsNullOrEmpty(Type))
+            {
+                builder.Append($" type='{Type}'");
+            }
+            if (string.IsNullOrEmpty(HRef))
+            {
+                builder.Append($" href='{HRef}'");
+            }
+            builder.Append(">");
+            foreach (var item in _linkData)
+            {
+                builder.Append(item.ToString());
+                builder.Append(" ");
+            }
+            builder.Append("</a>");
+            return builder.ToString();
         }
 
         internal void Load(XElement xLink)
@@ -36,22 +54,63 @@ namespace FB2Library.Elements
                 throw new ArgumentException("Element of wrong type passed", "xLink");
             }
 
-            LinkText = null;
-            //if (xLink.Value != null)
+            if (xLink.HasElements)
             {
-                LinkText = new SimpleText();
-                try
+                IEnumerable<XNode> childElements = xLink.Nodes();
+                foreach (var element in childElements)
                 {
-                    LinkText.Load(xLink);
+                    if ((element.NodeType == XmlNodeType.Element) && !IsSimpleText(element))
+                    {
+                        XElement xElement = (XElement)element;
+                        if (xElement.Name.LocalName == InlineImageItem.Fb2InlineImageElementName)
+                        {
+                            InlineImageItem image = new InlineImageItem();
+                            try
+                            {
+                                image.Load(xElement);
+                                _linkData.Add(image);
+                            }
+                            catch (Exception)
+                            {
+                            }
+                        }
+                        else if (xElement.Name.LocalName == StyleItem.StyleItemName)
+                        {
+                            StyleItem styleItem = new StyleItem();
+                            try
+                            {
+                                styleItem.Load(xElement);
+                                _linkData.Add(styleItem);
+                            }
+                            catch (Exception)
+                            {
+                            }
+                        }
+                    }
+                    else
+                    {
+                        SimpleText text = new SimpleText();
+                        try
+                        {
+                            text.Load(element);
+                            _linkData.Add(text);
+                        }
+                        catch (Exception)
+                        {
+                            continue;
+                        }
+                    }
                 }
-                catch (Exception)
-                {
-                    LinkText = null;
-                }
+            }
+            else if (!string.IsNullOrEmpty(xLink.Value))
+            {
+                SimpleText text = new SimpleText();
+                text.Load(xLink);
+                _linkData.Add(text);
             }
 
             XAttribute xTypeAttr = xLink.Attribute("type");
-            if ((xTypeAttr != null)&& (xTypeAttr.Value != null))
+            if ((xTypeAttr != null) && (xTypeAttr.Value != null))
             {
                 Type = xTypeAttr.Value;
             }
@@ -64,20 +123,41 @@ namespace FB2Library.Elements
 
         }
 
+        private bool IsSimpleText(XNode element)
+        {
+            // if not element than we assume simple text
+            if (element.NodeType != XmlNodeType.Element)
+            {
+                return true;
+            }
+            XElement xElement = (XElement)element;
+            if (xElement.Name.LocalName == InternalLinkItem.Fb2InternalLinkElementName)
+            {
+                throw new ArgumentException("Schema doesn't support nested links");
+            }
+            switch (xElement.Name.LocalName)
+            {
+                case InlineImageItem.Fb2InlineImageElementName:
+                case StyleItem.StyleItemName:
+                    return false;
+            }
+            return true;
+        }
+
         public XNode ToXML()
         {
             XElement xLink = new XElement(Fb2Const.fb2DefaultNamespace + Fb2InternalLinkElementName);
             if (!string.IsNullOrEmpty(Type))
-            { 
-                xLink.Add(new XAttribute("type",Type));
-            }
-            if(!string.IsNullOrEmpty(HRef))
             {
-                xLink.Add(new XAttribute(lNamespace + "href",HRef));
+                xLink.Add(new XAttribute("type", Type));
             }
-            if (LinkText != null)
+            if (!string.IsNullOrEmpty(HRef))
             {
-                xLink.Add(LinkText.ToXML());
+                xLink.Add(new XAttribute(lNamespace + "href", HRef));
+            }
+            foreach (StyleType childElements in _linkData)
+            {
+                xLink.Add(childElements.ToXML());
             }
             return xLink;
         }

--- a/FB2Library/Elements/ParagraphItem.cs
+++ b/FB2Library/Elements/ParagraphItem.cs
@@ -22,9 +22,9 @@ namespace FB2Library.Elements
         {
             return Fb2ParagraphElementName;
         }
-        
+
         internal const string Fb2ParagraphElementName = "p";
-        
+
 
         public override string ToString()
         {
@@ -78,24 +78,36 @@ namespace FB2Library.Elements
                             }
                             catch (Exception)
                             {
-                            }                            
+                            }
+                        }
+                        else if (xElement.Name.LocalName == StyleItem.StyleItemName)
+                        {
+                            StyleItem styleItem = new StyleItem();
+                            try
+                            {
+                                styleItem.Load(xElement);
+                                paragraphData.Add(styleItem);
+                            }
+                            catch (Exception)
+                            {
+                            }
                         }
                     }
                     else //if ( element.NodeType != XmlNodeType.Whitespace)
                     {
-                            SimpleText text = new SimpleText();
-                            try
-                            {
-                                text.Load(element);
-                                paragraphData.Add(text);
-                            }
-                            catch (Exception)
-                            {
-                                continue;
-                            }
+                        SimpleText text = new SimpleText();
+                        try
+                        {
+                            text.Load(element);
+                            paragraphData.Add(text);
+                        }
+                        catch (Exception)
+                        {
+                            continue;
+                        }
                     }
                 }
-               
+
             }
             else if (!string.IsNullOrEmpty(xParagraph.Value))
             {
@@ -122,7 +134,7 @@ namespace FB2Library.Elements
             {
                 Lang = xLang.Value;
             }
-            
+
         }
 
         internal virtual void Load(XElement xParagraph)
@@ -153,8 +165,9 @@ namespace FB2Library.Elements
             {
                 case InternalLinkItem.Fb2InternalLinkElementName:
                 case InlineImageItem.Fb2InlineImageElementName:
+                case StyleItem.StyleItemName:
                     return false;
-                    
+
             }
             return true;
         }

--- a/FB2Library/Elements/StyleItem.cs
+++ b/FB2Library/Elements/StyleItem.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace FB2Library.Elements
+{
+    /// <summary>
+    /// Represents FB2 style tag
+    /// </summary>
+    public class StyleItem : IFb2TextItem, StyleType
+    {
+        internal const string StyleItemName = "style";
+
+        /// <summary>
+        /// Get/Set name of the sequence
+        /// </summary>
+        public string Name { get; set; }
+        /// <summary>
+        /// Get/Set language
+        /// </summary>
+        public string Lang { get; set; }
+        public List<StyleType> StyleData { get; set; } = new List<StyleType>();
+        protected virtual string GetElementName()
+        {
+            return StyleItemName;
+        }
+        public override string ToString()
+        {
+            StringBuilder builder = new StringBuilder($"<style name='{Name}' xml:lang='{Lang}'>");
+            foreach (var textItem in StyleData)
+            {
+                builder.Append(textItem.ToString());
+                builder.Append(" ");
+            }
+            builder.Append("</style>");
+            return builder.ToString();
+        }
+        /// <summary>
+        /// Load element data from the node
+        /// </summary>
+        /// <param name="xStyle"></param>
+        public void Load(XElement xStyle)
+        {
+            if (xStyle == null)
+            {
+                throw new ArgumentNullException("style");
+            }
+            if (xStyle.Name.LocalName != StyleItemName)
+            {
+                throw new ArgumentException(string.Format("The element is of type {0} while StyleItem accepts only {1} types", xStyle.Name.LocalName, StyleItemName));
+            }
+
+            Lang = null;
+            XAttribute xLang = xStyle.Attribute(XNamespace.Xml + "lang");
+            if (xLang != null)
+            {
+                Lang = xLang.Value;
+            }
+
+            Name = string.Empty;
+            XAttribute xName = xStyle.Attribute("name");
+            if (xName != null && xName.Value != null)
+            {
+                Name = xName.Value;
+            }
+
+            if (xStyle.HasElements)
+            {
+                IEnumerable<XNode> childElements = xStyle.Nodes();
+                foreach (var element in childElements)
+                {
+                    if ((element.NodeType == XmlNodeType.Element) && !IsSimpleText(element))
+                    {
+                        XElement xElement = (XElement)element;
+                        if (xElement.Name.LocalName == InlineImageItem.Fb2InlineImageElementName)
+                        {
+                            InlineImageItem image = new InlineImageItem();
+                            try
+                            {
+                                image.Load(xElement);
+                                StyleData.Add(image);
+                            }
+                            catch (Exception)
+                            {
+                            }
+                        }
+                        else if (xElement.Name.LocalName == InternalLinkItem.Fb2InternalLinkElementName)
+                        {
+                            InternalLinkItem linkItem = new InternalLinkItem();
+                            try
+                            {
+                                linkItem.Load(xElement);
+                                StyleData.Add(linkItem);
+                            }
+                            catch (Exception)
+                            {
+                            }
+                        }
+                        else if (xElement.Name.LocalName == StyleItemName)
+                        {
+                            StyleItem styleItem = new StyleItem();
+                            try
+                            {
+                                styleItem.Load(xElement);
+                                StyleData.Add(styleItem);
+                            }
+                            catch (Exception)
+                            {
+                            }
+                        }
+                    }
+                    else
+                    {
+                        SimpleText text = new SimpleText();
+                        try
+                        {
+                            text.Load(element);
+                            StyleData.Add(text);
+                        }
+                        catch (Exception)
+                        {
+                        }
+                    }
+                }
+
+            }
+            else if (!string.IsNullOrEmpty(xStyle.Value))
+            {
+                SimpleText text = new SimpleText();
+                text.Load(xStyle);
+                StyleData.Add(text);
+            }
+        }
+        private bool IsSimpleText(XNode element)
+        {
+            // if not element than we assume simple text
+            if (element.NodeType != XmlNodeType.Element)
+            {
+                return true;
+            }
+            XElement xElement = (XElement)element;
+            switch (xElement.Name.LocalName)
+            {
+                case InternalLinkItem.Fb2InternalLinkElementName:
+                case InlineImageItem.Fb2InlineImageElementName:
+                case StyleItem.StyleItemName:
+                    return false;
+            }
+            return true;
+        }
+        public XNode ToXML()
+        {
+            if (Name == null || string.IsNullOrEmpty(Name))
+            {
+                throw new Exception("Name attribute is required by standard");
+            }
+            XElement xStyle = new XElement(Fb2Const.fb2DefaultNamespace + StyleItemName, new XAttribute("name", Name));
+            if (!string.IsNullOrEmpty(Lang))
+            {
+                xStyle.Add(new XAttribute(XNamespace.Xml + "lang", Lang));
+            }
+            foreach (StyleType childElements in StyleData)
+            {
+                xStyle.Add(childElements.ToXML());
+            }
+            return xStyle;
+        }
+    }
+}


### PR DESCRIPTION
* Fix for [Fix: 'a' tag doesn't support sub-tags](https://github.com/wcoder/FB2Library/pull/7) included

Add processing of the tag 'style' original spec contains. Inside fb2 book, it looks like this:
`<style name="somestyle">some string</style>`. Without this fix, if the book contains this tag, the following exception will be thrown:
```
System.ArgumentNullException: The empty string '' is not a valid local name. (Parameter 'name')
   at System.Xml.XmlConvert.VerifyNCName(String name, ExceptionType exceptionType)
   at System.Xml.XmlConvert.VerifyNCName(String name)
   at System.Xml.Linq.XName..ctor(XNamespace ns, String localName)
   at System.Xml.Linq.XNamespace.GetName(String localName, Int32 index, Int32 count)
   at System.Xml.Linq.XNamespace.GetName(String localName)
   at System.Xml.Linq.XNamespace.op_Addition(XNamespace ns, String localName)
   at FB2Library.Elements.SimpleText.ToXML() in FB2Library\Elements\SimpleText.cs:line 218
   at FB2Library.Elements.ParagraphItem.ToXML() in FB2Library\Elements\ParagraphItem.cs:line 180
   at FB2Library.Elements.SectionItem.ToXML() in FB2Library\Elements\SectionItem.cs:line 320
   at FB2Library.Elements.BodyItem.ToXML() in FB2Library\Elements\BodyItem.cs:line 164
   at FB2Library.FB2File.ToXML(Boolean bExportHeaderOnly) in FB2Library\FB2File.cs:line 420
```
