### PR TITLE
Error on load book then is has windows-1521 codepage.

### DIFF
--- a/samples/FBLibrary.Sample.ConsoleApp/Program.cs
+++ b/samples/FBLibrary.Sample.ConsoleApp/Program.cs
@@ -2,11 +2,16 @@
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Text;
 using System.Xml;
 using FB2Library;
 using FB2Library.Elements;
 
+
+Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
 var filePath = Path.Combine("..", "..", "..", "..", "..", "files", "test.fb2");
+
 await using var fileStream = new FileStream(filePath, FileMode.Open);
 
 var readerSettings = new XmlReaderSettings


### PR DESCRIPTION
Console application raise System.Xml.XmlExceptiong when book has codepage like windows-1251.


The .NET Framework for the Windows desktop supports a large set of Unicode and code page encodings. .NET Core, on the other hand, supports only the following encodings:

        ASCII (code page 20127), which is returned by the Encoding.ASCII property.
        ISO-8859-1 (code page 28591).
        UTF-7 (code page 65000), which is returned by the Encoding.UTF7 property.
        UTF-8 (code page 65001), which is returned by the Encoding.UTF8 property.
        UTF-16 and UTF-16LE (code page 1200), which is returned by the Encoding.Unicode property.
        UTF-16BE (code page 1201), which is instantiated by calling the UnicodeEncoding.UnicodeEncoding or UnicodeEncoding.UnicodeEncoding constructor with a bigEndian value of true.
        UTF-32 and UTF-32LE (code page 12000), which is returned by the Encoding.UTF32 property.
        UTF-32BE (code page 12001), which is instantiated by calling an UTF32Encoding constructor that has a bigEndian parameter and providing a value of true in the method call.

